### PR TITLE
Get Lithium or light elements transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,15 @@ docs/_build/
 # PyBuilder
 target/
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
 #####=== Jython ===#####
 
 *.pyc

--- a/pyxray/base.py
+++ b/pyxray/base.py
@@ -241,7 +241,7 @@ class _DatabaseMixin(metaclass=abc.ABCMeta):
 
         :arg file: file for output, default to standard out
         """
-        header = ['IUPAC', 'Siegbahn', 'Energy (eV)', 'Probability']
+        header = ['IUPAC', 'Siegbahn', 'Energy (eV)', 'Probability', 'Relative weight']
 
         rows = []
         for xray_transition in self.element_xray_transitions(element):
@@ -265,7 +265,12 @@ class _DatabaseMixin(metaclass=abc.ABCMeta):
             except:
                 probability = ''
 
-            rows.append([iupac, siegbahn, energy_eV, probability])
+            try:
+                relative_weight = self.xray_transition_relative_weight(element, xray_transition)
+            except:
+                relative_weight = ''
+
+            rows.append([iupac, siegbahn, energy_eV, probability, relative_weight])
 
         rows.sort(key=operator.itemgetter(2))
 

--- a/pyxray/sql/data.py
+++ b/pyxray/sql/data.py
@@ -6,6 +6,7 @@ import logging
 
 # Third party modules.
 import sqlalchemy.sql
+from sqlalchemy import or_
 
 # Local modules.
 from pyxray.base import _DatabaseMixin, NotFound
@@ -367,9 +368,39 @@ class SqlDatabase(_DatabaseMixin, SqlBase):
             self._update_xray_transition(builder, table_probability, xray_transition, search=True)
 
         transitions = []
-        for src_n, src_l, src_j_n, dst_n, dst_l, dst_j_n in self._execute_many(builder):
-            transition = descriptor.XrayTransition(src_n, src_l, src_j_n, dst_n, dst_l, dst_j_n)
-            transitions.append(transition)
+        try:
+            for src_n, src_l, src_j_n, dst_n, dst_l, dst_j_n in self._execute_many(builder):
+                transition = descriptor.XrayTransition(src_n, src_l, src_j_n, dst_n, dst_l, dst_j_n)
+                transitions.append(transition)
+        except NotFound:
+            logger.info("No transition found for {}".format(element))
+
+        if len(transitions) == 0:
+            table_relative_weight = self.require_table(property.XrayTransitionRelativeWeight)
+            builder = StatementBuilder()
+            builder.add_column(table_xray.c['source_principal_quantum_number'])
+            builder.add_column(table_xray.c['source_azimuthal_quantum_number'])
+            builder.add_column(table_xray.c['source_total_angular_momentum_nominator'])
+            builder.add_column(table_xray.c['destination_principal_quantum_number'])
+            builder.add_column(table_xray.c['destination_azimuthal_quantum_number'])
+            builder.add_column(table_xray.c['destination_total_angular_momentum_nominator'])
+            builder.add_join(table_relative_weight, table_xray, table_relative_weight.c['xray_transition_id'] == table_xray.c['id'])
+            builder.add_clause(table_relative_weight.c['value'] > 0.0)
+            self._update_element(builder, table_relative_weight, element)
+            self._update_reference(builder, table_relative_weight, reference)
+            if xray_transition is not None:
+                self._update_xray_transition(builder, table_relative_weight, xray_transition, search=True)
+
+            transitions = []
+            try:
+                for src_n, src_l, src_j_n, dst_n, dst_l, dst_j_n in self._execute_many(builder):
+                    transition = descriptor.XrayTransition(src_n, src_l, src_j_n, dst_n, dst_l, dst_j_n)
+                    transitions.append(transition)
+            except NotFound:
+                logger.info("No transition found for {}".format(element))
+
+        if len(transitions) == 0:
+            raise NotFound
 
         return tuple(transitions)
 

--- a/pyxray/sql/data.py
+++ b/pyxray/sql/data.py
@@ -6,7 +6,6 @@ import logging
 
 # Third party modules.
 import sqlalchemy.sql
-from sqlalchemy import or_
 
 # Local modules.
 from pyxray.base import _DatabaseMixin, NotFound

--- a/tests/sql/test_data.py
+++ b/tests/sql/test_data.py
@@ -13,6 +13,7 @@ import pytest
 # Local modules.
 import pyxray.descriptor as descriptor
 from pyxray.sql.data import SqlDatabase, NotFound
+import pyxray.data
 
 # Globals and constants variables.
 K = descriptor.AtomicSubshell(1, 0, 1)
@@ -22,6 +23,10 @@ L2 = descriptor.AtomicSubshell(2, 1, 1)
 @pytest.fixture(scope='session')
 def database(builder):
     return SqlDatabase(builder.engine)
+
+@pytest.fixture
+def database_real(tmp_path):
+    return pyxray.data.database
 
 def test_add_preferred_reference(database):
     database.clear_preferred_references()
@@ -129,6 +134,17 @@ def test_element_xray_transitions(database, element, reference):
 ])
 def test_element_xray_transitions_with_xray_transition(database, xray_transition, expected):
     transitions = database.element_xray_transitions(118, xray_transition)
+    assert len(transitions) == expected
+
+@pytest.mark.parametrize('element, expected', [
+    (13, 14),
+    (6, 2),
+    (5, 3),
+    (4, 3),
+    (3, 2),
+])
+def test_element_xray_transitions(database_real, element, expected):
+    transitions = database_real.element_xray_transitions(element)
     assert len(transitions) == expected
 
 @pytest.mark.parametrize('element,reference', [(118, 'unknown'), (1, None)])


### PR DESCRIPTION
This pull request allow to get transitions for light elements when no probability are available in the database, but a relative weight is available using `element_xray_transitions`. See commit 3021322ac9ba2f1f29b213cc2617ff29d0d479e3.

The implementation is not great. I was not able to combine `table_probability` and `table_relative_weight` in one SQL operation, the SQL query did not work. So the implementation duplicates the SQL query for `table_probability`, but using `table_relative_weight` if the number of transitions found with `table_probability` is zero.

The `print_element_xray_transitions` is also modified to output the relative weight of each transition.

A test was added to test the new functionality of `element_xray_transitions` and tests pass.

What I try and it did not work was to add a join for `table_relative_weight` and modify the clause `table_probability.c['value'] > 0.0` to use a `sqlalchemy.or_` on both. Various was tried and either the SQL gives an error or the number of transitions was too large (>1000).

Thanks,
Hendrix