### PR TITLE
Remove preferred reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Variables of the methods are defined as follows
 
     * `Reference <http://github.com/openmicroanalysis/pyxray/blob/master/pyxray/descriptor.py>`_ object
     * BibTeX key of a reference
-    * ``None``, the default reference will be used or the first reference found
+    * ``None``, the newest reference will be returned
 
 Element properties
 ------------------

--- a/pyxray/base.py
+++ b/pyxray/base.py
@@ -56,38 +56,6 @@ _docextras = {
 
 class _DatabaseMixin(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def get_preferred_references(self):
-        """
-        Return the BibTeX keys of the preferred references.
-
-        If no reference is specified when calling a method, the value for the first preferred reference is returned.
-        If no preferred reference, the first value is returned.
-
-        :return: preferred references
-        :rtype: :class:`tuple`
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    @formatdoc(**_docextras)
-    def add_preferred_reference(self, reference):
-        """
-        Adds a preferred reference.
-
-        :arg reference: :class:`Reference` or its BibTeX key
-
-        {exception}
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def clear_preferred_references(self):
-        """
-        Clear all added preferred references.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     @formatdoc(**_docextras)
     def element(self, element):  # pragma: no cover
         """

--- a/pyxray/data.py
+++ b/pyxray/data.py
@@ -3,9 +3,6 @@ Current implementation of the database
 """
 
 __all__ = [
-    "get_preferred_references",
-    "add_preferred_reference",
-    "clear_preferred_references",
     "element",
     "element_atomic_number",
     "element_symbol",
@@ -48,15 +45,6 @@ logger = logging.getLogger(__name__)
 
 
 class _EmptyDatabase(_DatabaseMixin):
-    def get_preferred_references(self):
-        return ()
-
-    def add_preferred_reference(self, reference):
-        pass
-
-    def clear_preferred_references(self):
-        pass
-
     def element(self, element):  # pragma: no cover
         raise NotFound
 
@@ -169,9 +157,6 @@ except:
     logger.error("No SQL database found")
     database = _EmptyDatabase()
 
-get_preferred_references = database.get_preferred_references
-add_preferred_reference = database.add_preferred_reference
-clear_preferred_references = database.clear_preferred_references
 element = database.element
 element_atomic_number = database.element_atomic_number
 element_symbol = database.element_symbol

--- a/pyxray/descriptor.py
+++ b/pyxray/descriptor.py
@@ -352,7 +352,7 @@ class Notation:
 class Reference:
     bibtexkey: str
     author: str = None
-    year: str = None
+    year: int = None
     title: str = None
     type: str = None
     booktitle: str = None

--- a/tests/sql/conftest.py
+++ b/tests/sql/conftest.py
@@ -20,8 +20,8 @@ L2 = descriptor.AtomicSubshell(2, 1, 1)
 
 class MockParser(_Parser):
     def __iter__(self):
-        reference = descriptor.Reference("lee1966")
-        reference2 = descriptor.Reference("doe2016")
+        reference = descriptor.Reference("lee1966", year=1966)
+        reference2 = descriptor.Reference("doe2016", year=2016)
         element = descriptor.Element(118)
         atomic_shell = descriptor.AtomicShell(1)
         transition = descriptor.XrayTransition(L3, K)

--- a/tests/sql/test_data.py
+++ b/tests/sql/test_data.py
@@ -2,10 +2,6 @@
 """ """
 
 # Standard library modules.
-import os
-import tempfile
-import shutil
-import sqlite3
 
 # Third party modules.
 import pytest
@@ -29,22 +25,6 @@ def database(builder):
 @pytest.fixture
 def database_real(tmp_path):
     return pyxray.data.database
-
-
-def test_add_preferred_reference(database):
-    database.clear_preferred_references()
-    database.add_preferred_reference("lee1966")
-
-    assert len(database.get_preferred_references()) == 1
-    assert "lee1966" in database.get_preferred_references()
-
-    database.clear_preferred_references()
-    assert len(database.get_preferred_references()) == 0
-
-
-def test_add_preferred_reference_not_found(database):
-    with pytest.raises(NotFound):
-        database.add_preferred_reference("foo")
 
 
 @pytest.mark.parametrize("element", [118, "Vi", "Vibranium"])
@@ -108,7 +88,8 @@ def test_element_name_notfound_wrong_reference(database):
 
 
 def test_element_atomic_weight_no_reference(database):
-    assert database.element_atomic_weight(118) == pytest.approx(999.1, abs=1e-2)
+    # doe2016 (111.1) takes precedence over lee1966 (999.1) because it is newer
+    assert database.element_atomic_weight(118) == pytest.approx(111.1, abs=1e-2)
 
 
 def test_element_atomic_weight_lee1966(database):
@@ -121,18 +102,6 @@ def test_element_atomic_weight_doe2016(database):
     assert database.element_atomic_weight(118, "doe2016") == pytest.approx(
         111.1, abs=1e-2
     )
-
-
-def test_element_atomic_weight_preferred_reference(database):
-    database.clear_preferred_references()
-    database.add_preferred_reference("doe2016")
-    assert database.element_atomic_weight(118) == pytest.approx(111.1, abs=1e-2)
-
-    database.clear_preferred_references()
-    database.add_preferred_reference("lee1966")
-    assert database.element_atomic_weight(118) == pytest.approx(999.1, abs=1e-2)
-
-    database.clear_preferred_references()
 
 
 @pytest.mark.parametrize("element", [118, "Vi", "Vibranium"])


### PR DESCRIPTION
The preferred reference concept was only working for some functions and never set by default. This PR removes methods to set/clear preferred references and implements the simpler rule that the value for the newest reference (by year) is returned if there is more than one references.

An issue was created to add capability to return values of all references (#23).